### PR TITLE
Update build and deployment to work with minikube

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,18 @@ kubectl create -f deploy/role_binding.yaml
 ```
 
 ### How do you run this?
-Honestly since this is new and I haven't done much yet I've just used 'operator-sdk up local' from within the directory.
+Use 'operator-sdk up local' from within this operator's directory.
+
+Alternatively, use it as part of your minikube cluster:
+```
+minikube start
+kubectl config use-context minikube
+cd $GOPATH/src/github.com/c-e-brumm/false-hive
+oc create -f ./deploy
+```
+
+### Building the latest image
+```
+docker build -f build/Dockerfile . -t quay.io/openshift-sre/false-hive:latest
+docker push quay.io/openshift-sre/false-hive:latest
+```

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,14 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+ENV OPERATOR_PATH=/go/src/github.com/c-e-brumm/false-hive
+COPY . ${OPERATOR_PATH}
+WORKDIR ${OPERATOR_PATH}
+#RUN GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -gcflags="all=-trimpath=${GOPATH}" -asmflags="all=-trimpath=${GOPATH}"  -o build/_output/bin/${OPERATOR_BIN} ./cmd/manager
+RUN GOENV=GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/_output/bin/false-hive ./cmd/manager
+
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+ENV OPERATOR_PATH=/go/src/github.com/c-e-brumm/false-hive \
+    OPERATOR_BIN=false-hive
 
-ENV OPERATOR=/usr/local/bin/false-hive \
-    USER_UID=1001 \
-    USER_NAME=false-hive
+WORKDIR /root/
+COPY --from=builder ${OPERATOR_PATH}/build/_output/bin/${OPERATOR_BIN} /usr/local/bin/${OPERATOR_BIN}
 
-# install operator binary
-COPY build/_output/bin/false-hive ${OPERATOR}
-
-COPY build/bin /usr/local/bin
-RUN  /usr/local/bin/user_setup
-
-ENTRYPOINT ["/usr/local/bin/entrypoint"]
-
-USER ${USER_UID}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: false-hive
           # Replace this with the built image name
-          image: REPLACE_IMAGE
+          image: quay.io/openshift-sre/false-hive:latest
           command:
           - false-hive
           imagePullPolicy: Always

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,49 +1,8 @@
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: false-hive
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - certman.managed.openshift.io
-  resources:
-  - '*'
-  - certificaterequests
-  verbs:
-  - '*'
 - apiGroups:
   - hive.openshift.io
   attributeRestrictions: null
@@ -57,11 +16,3 @@ rules:
   - watch
   - update
   - patch
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - '*'
-
-

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: false-hive
 subjects:
 - kind: ServiceAccount
   name: false-hive
+  namespace: default
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: false-hive
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
* Updated role and rolebinding to give operator permission to view
  clusterdeployment objects in a cluster-wide scope.
* Update Dockerfile to use a multi-stage go build + image build.
* Update docs with usage info on testing with minikube.
* Update deployment file to use image hosted on quay.io.