### PR TITLE
Add the ability to get pods and configmaps

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -16,3 +16,16 @@ rules:
   - watch
   - update
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get


### PR DESCRIPTION
Testing in minikube today, the operator was crashing until
I gave it permission to get/create configmaps, and get pods.